### PR TITLE
add control-plane label to support new kube version

### DIFF
--- a/helm/drbd-adapter/values.yaml
+++ b/helm/drbd-adapter/values.yaml
@@ -13,3 +13,5 @@ affinity:
       - matchExpressions:
         - key: node-role.kubernetes.io/master
           operator: DoesNotExist
+        - key: node-role.kubernetes.io/control-plane
+          operator: DoesNotExist


### PR DESCRIPTION
Fix: https://github.com/hwameistor/drbd-adapter/issues/5