### PR TITLE
[Feature] Auto-Detect OS distros and also allow manual input  

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -31,3 +31,23 @@ jobs:
           config: helm/.cr/config.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Run yq
+        uses: mikefarah/yq@master
+        run: |
+          sleep 300
+          curl https://raw.githubusercontent.com/$( echo ${{ github.repository_owner }} | tr 'A-Z' 'a-z' )/hwameistor/gh-pages/index.yaml > hms.yaml
+          curl https://raw.githubusercontent.com/$( echo ${{ github.repository_owner }} | tr 'A-Z' 'a-z' )/drbd-adapter/gh-pages/index.yaml > dra.yaml
+          yq eval-all '. as $item ireduce ({}; . * $item)' hms.yaml dra.yaml > index.yaml
+          cat index.yaml
+      - name: Pushes test file
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source_file: 'index.yaml'
+          destination_repo: 'hwameistor/hwameistor'
+          destination_folder: '/'
+          destination_branch: gh-pages
+          user_email: 'alexzhc@hotmail.com'
+          user_name: 'alex'
+          commit_message: 'Update chart index with the latest drbd-adapter release'

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -31,8 +31,9 @@ jobs:
           config: helm/.cr/config.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Run yq
+      - name: Set up yq
         uses: mikefarah/yq@master
+      - name: Merge index.yaml
         run: |
           sleep 300
           curl https://raw.githubusercontent.com/$( echo ${{ github.repository_owner }} | tr 'A-Z' 'a-z' )/hwameistor/gh-pages/index.yaml > hms.yaml

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ LINBIT/drbd <https://github.com/LINBIT/drbd/tree/drbd-9.1/docker>
 
 * x86_64
 
-## OS Support
+## OS Distro Support
 
 * RHEL/CentOS 7
 * RHEL/CentOS 7
@@ -45,7 +45,7 @@ $ yum install -y kernel-devel-$(uname -r)
 $ apt-get install -y linux-headers-$(uname -r)
 ```
 
-### Helm Charts
+### Deploy by Helm Charts
 Deploy the below `DaemonSet`. It will bring up a pod on each kubernetes worker node to install DRBD modules and tools:
 
 ```
@@ -57,3 +57,22 @@ $ helm pull hwameistor/drbd-adapter --untar
 
 $ helm install drbd-adapter ./drbd-adapter -n hwameistor --create-namespace
 ```
+
+### Set OS Distros
+
+By default, OS distros are auto-detected by helm "lookup" function.
+
+However it can be overridden by adding values to the array "distros: []" in values.yaml.
+
+For example:
+
+```yaml
+distros: 
+- rhel7
+- rhel8
+- bionic
+#- focal
+#- jammy
+```
+
+**Distros that are not supported will be ignored.**

--- a/docker-drbd9/Dockerfile.bionic
+++ b/docker-drbd9/Dockerfile.bionic
@@ -20,3 +20,5 @@ RUN ln -vs /usr/bin/python2 /usr/bin/python3
 RUN ln -vs /usr/bin/python2 /usr/bin/python3.6
 
 ENTRYPOINT /entry.sh
+
+ENV DRBD_VERSION 9.1.8

--- a/docker-drbd9/Dockerfile.flatcar
+++ b/docker-drbd9/Dockerfile.flatcar
@@ -6,3 +6,5 @@ COPY /drbd.tar.gz /
 COPY /entry.sh /
 RUN chmod +x /entry.sh
 ENTRYPOINT /entry.sh
+
+ENV DRBD_VERSION 9.1.8

--- a/docker-drbd9/Dockerfile.focal
+++ b/docker-drbd9/Dockerfile.focal
@@ -20,3 +20,5 @@ RUN ln -vs /usr/bin/python2 /usr/bin/python3
 RUN ln -vs /usr/bin/python2 /usr/bin/python3.6
 
 ENTRYPOINT /entry.sh
+
+ENV DRBD_VERSION 9.1.8

--- a/docker-drbd9/Dockerfile.jammy
+++ b/docker-drbd9/Dockerfile.jammy
@@ -14,3 +14,5 @@ COPY /pkgs /pkgs
 COPY /entry.sh /
 RUN chmod +x /entry.sh
 ENTRYPOINT /entry.sh
+
+ENV DRBD_VERSION 9.1.8

--- a/docker-drbd9/Dockerfile.sles15sp1
+++ b/docker-drbd9/Dockerfile.sles15sp1
@@ -10,3 +10,5 @@ COPY /pkgs /pkgs
 COPY /entry.sh /
 RUN chmod +x /entry.sh
 ENTRYPOINT /entry.sh
+
+ENV DRBD_VERSION 9.1.8

--- a/docker-shipper/entrypoint.adapter.sh
+++ b/docker-shipper/entrypoint.adapter.sh
@@ -1,25 +1,47 @@
-#!/bin/bash -x 
+#!/bin/bash -x
+## Maintainer Alex Zheng <alex.zheng@daocloud.io>
+## This is a wrapper scripts to have drbd9 containers automatically adapt host distros
 
-# Check if image matches os type
-
+## Check if image matches os type
 which lbdisttool.py
 
-image_type="$(lbdisttool.py -l | awk -F'.' '{print $1}' )"
-host_type="$(lbdisttool.py -l --os-release /etc/host-release | awk -F'.' '{print $1}' )"
+image_dist="$(lbdisttool.py -l | awk -F'.' '{print $1}' )"
+host_dist="$(lbdisttool.py -l --os-release /etc/host-release | awk -F'.' '{print $1}' )"
 
 # For Kylin v10, use RHEL 8 base for now
-if [ -z $host_type ] \
+if [ -z $host_dist ] \
    && uname -r | grep -i '.ky10.' \
    && grep -iw kylin /etc/host-release; then
    echo "Host distro is Kylin V10"
-   host_type=rhel8
+   host_dist=rhel8
 fi
 
-if [[ $host_type != $image_type ]]; then 
+# Gracefully exit for distro mismatch, so that next initContainer may start
+if [[ $host_dist != $image_dist ]]; then 
    echo "Image type does not match OS type, skip !" 
    exit 0
 fi
 
+## Unload current drbd modules from kernel if it is lower than the target version 
+# (only possible if no [drbd_xxx] process is running)
+RUNNING_DRBD_VERSION=$( cat /proc/drbd | awk '/^version:/ {print $2}' )
+
+if [ -z $RUNNING_DRBD_VERSION ]; then
+   echo "No DRBD Module is loaded"
+elif [[ $RUNNING_DRBD_VERSION == $DRBD_VERSION ]] || \
+     [[ $( printf "$RUNNING_DRBD_VERSION\n$DRBD_VERSION" | sort -V | tail -1 ) != $DRBD_VERSION ]]
+then
+   echo "The loaded DRBD module version is already $RUNNING_DRBD_VERSION"
+else
+   echo "The loaded DRBD module version $RUNNING_DRBD_VERSION is lower than $DRBD_VERSION"
+   for i in drbd_transport_tcp drbd; do
+      if lsmod | grep -w $i; then
+         rmmod $i || true
+      fi
+   done
+fi
+
+## Main Logic
 # If no shipped module is found, then compile from source
 if LB_HOW=shipped_modules bash -x /entry.sh; then
    echo "Successfully loaded shipped module"
@@ -28,15 +50,25 @@ elif LB_HOW=compile bash -x /entry.sh; then
 fi
 
 # Drop modules to the host so it can independently load from OS
-KODIR="/lib/modules/$(uname -r)/extra/drbd"
 if [[ $LB_DROP == yes ]]; then
+
    # drop modules
-   mkdir -vp $(basename "$KODIR") 
-   cp -vfr /tmp/ko "${KODIR}"
+   if [[ $host_dist =~ rhel ]]; then
+      KODIR="/lib/modules/$(uname -r)/extra/drbd"
+   elif [[ $host_dist =~ bionic|focal|jammy ]]; then
+      KODIR="/lib/modules/$(uname -r)/updates/dkms/drbd"
+   else
+      KODIR="/lib/modules/$(uname -r)/drbd"
+   fi 
+   mkdir -vp "$KODIR"
+   cp -vf /tmp/ko/*.ko "${KODIR}/"
+
    # register modules
    depmod -a
+
    # onboot load modules 
    cp -vf /pkgs/drbd.modules-load.conf /etc/modules-load.d/drbd.conf
+
    # drop drbd utils
    cp -vf /pkgs/drbd-utils/* /usr-local-bin/
 fi

--- a/drbd-adapter.yaml
+++ b/drbd-adapter.yaml
@@ -1,0 +1,191 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: drbd-adapter
+  labels:
+    k8s-app: drbd-adapter
+spec:
+  selector:
+    matchLabels:
+      k8s-app: drbd-adapter
+  template:
+    metadata:
+      labels:
+        k8s-app: drbd-adapter
+    spec:
+      initContainers:
+      - name: shipper
+        image: {{ .Values.registry}}/drbd9-shipper:{{ .Values.drbdVersion}}
+        imagePullPolicy: {{ .Values.imagePullPolicy}}
+        volumeMounts:
+        - name: pkgs
+          mountPath: /pkgs
+
+      {{- range .Values.distros }}
+      {{- $dist := .  }}
+           - name: rhel7
+        image: {{ .Values.registry}}/drbd9-rhel7:{{ .Values.drbdVersion}}
+        imagePullPolicy: {{ .Values.imagePullPolicy}}
+        command: [ /pkgs/entrypoint.adapter.sh ]
+        securityContext:
+          privileged: true
+        env:
+        - name: LB_DROP
+          value: 'yes'
+        volumeMounts:
+        - name: centos-release
+          mountPath: /etc/centos-release
+          readOnly: true
+        - name: pkgs
+          mountPath: /pkgs
+        - name: os-release
+          mountPath: /etc/host-release
+          readOnly: true
+        - name: usr-src
+          mountPath: /usr/src
+          readOnly: true
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: usr-local-bin
+          mountPath: /usr-local-bin
+        - name: etc-modules-load
+          mountPath: /etc/modules-load.d
+      {{- end }}  
+
+
+
+      - name: rhel7
+        image: {{ .Values.registry}}/drbd9-rhel7:{{ .Values.drbdVersion}}
+        imagePullPolicy: {{ .Values.imagePullPolicy}}
+        command: [ /pkgs/entrypoint.adapter.sh ]
+        securityContext:
+          privileged: true
+        env:
+        - name: LB_DROP
+          value: 'yes'
+        volumeMounts:
+        - name: centos-release
+          mountPath: /etc/centos-release
+          readOnly: true
+        - name: pkgs
+          mountPath: /pkgs
+        - name: os-release
+          mountPath: /etc/host-release
+          readOnly: true
+        - name: usr-src
+          mountPath: /usr/src
+          readOnly: true
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: usr-local-bin
+          mountPath: /usr-local-bin
+        - name: etc-modules-load
+          mountPath: /etc/modules-load.d
+
+      - name: rhel8
+        image: {{ .Values.registry}}/drbd9-rhel8:{{ .Values.drbdVersion}}
+        imagePullPolicy: {{ .Values.imagePullPolicy}}
+        command: [ /pkgs/entrypoint.adapter.sh ]
+        securityContext:
+          privileged: true
+        env:
+        - name: LB_DROP
+          value: 'yes'
+        volumeMounts:
+        - name: centos-release
+          mountPath: /etc/centos-release
+          readOnly: true
+        - name: pkgs
+          mountPath: /pkgs
+        - name: os-release
+          mountPath: /etc/host-release
+          readOnly: true
+        - name: usr-src
+          mountPath: /usr/src
+          readOnly: true
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: usr-local-bin
+          mountPath: /usr-local-bin
+        - name: etc-modules-load
+          mountPath: /etc/modules-load.d
+
+      - name: bionic
+        image: {{ .Values.registry}}/drbd9-bionic:{{ .Values.drbdVersion}}
+        imagePullPolicy: {{ .Values.imagePullPolicy}}
+        command: [ /pkgs/entrypoint.adapter.sh ]
+        securityContext:
+          privileged: true
+        env:
+        - name: LB_DROP
+          value: 'yes'
+        volumeMounts:
+        - name: pkgs
+          mountPath: /pkgs
+        - name: os-release
+          mountPath: /etc/host-release
+          readOnly: true
+        - name: usr-src
+          mountPath: /usr/src
+          readOnly: true
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: usr-local-bin
+          mountPath: /usr-local-bin
+        - name: etc-modules-load
+          mountPath: /etc/modules-load.d
+
+      - name: focal
+        image: {{ .Values.registry}}/drbd9-focal:{{ .Values.drbdVersion}}
+        imagePullPolicy: {{ .Values.imagePullPolicy}}
+        command: [ /pkgs/entrypoint.adapter.sh ]
+        securityContext:
+          privileged: true
+        env:
+        - name: LB_DROP
+          value: 'yes'
+        volumeMounts:
+        - name: pkgs
+          mountPath: /pkgs
+        - name: os-release
+          mountPath: /etc/host-release
+          readOnly: true
+        - name: usr-src
+          mountPath: /usr/src
+          readOnly: true
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: usr-local-bin
+          mountPath: /usr-local-bin
+        - name: etc-modules-load
+          mountPath: /etc/modules-load.d
+
+      - name: jammy
+        image: {{ .Values.registry}}/drbd9-jammy:{{ .Values.drbdVersion}}
+        imagePullPolicy: {{ .Values.imagePullPolicy}}
+        command: [ /pkgs/entrypoint.adapter.sh ]
+        securityContext:
+          privileged: true
+        env:
+        - name: LB_DROP
+          value: 'yes'
+        volumeMounts:
+        - name: pkgs
+          mountPath: /pkgs
+        - name: os-release
+          mountPath: /etc/host-release
+          readOnly: true
+        - name: usr-src
+          mountPath: /usr/src
+          readOnly: true
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: usr-local-bin
+          mountPath: /usr-local-bin
+        - name: etc-modules-load
+          mountPath: /etc/modules-load.d
+
+      
+      affinity:
+        nodeAffinity:
+		 {{- toYaml .Values.affinity.nodeAffinity | nindent 10 }}

--- a/helm/drbd-adapter/Chart.yaml
+++ b/helm/drbd-adapter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/drbd-adapter/Chart.yaml
+++ b/helm/drbd-adapter/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.2"
+appVersion: 9.1.8

--- a/helm/drbd-adapter/templates/NOTES.txt
+++ b/helm/drbd-adapter/templates/NOTES.txt
@@ -1,7 +1,17 @@
 Thank you for installing {{ .Chart.Name }}.
 
-This is a tool image to help install drbd kernel modules and drbd utils.
+This is a tool image to help install DRBD kernel modules and DRBD utils.
 
-For now, we support rhel7, rhel8, rhel9, ubuntu.
+For now, it supports the following OS distros: 
 
-Read more info or want support more linux distributions, you can visit https://github.com/hwameistor/drbd-adapter.
+    RHEL/CentOS 7
+    RHEL/CentOS 8
+    Ubuntu 18 Bionic
+    Ubuntu 20 Focal
+    Ubuntu 22 Jammy
+
+OS distros are by default auto-detected as "distroAutoDetect: true" is set in values.yaml
+
+If you want to manually specify OS distros, set "distroAutoDetect: false" and add to "distros: []" in values.yaml
+
+Read more info at https://github.com/hwameistor/drbd-adapter.

--- a/helm/drbd-adapter/templates/drbd-adapter.yaml
+++ b/helm/drbd-adapter/templates/drbd-adapter.yaml
@@ -20,8 +20,10 @@ spec:
         volumeMounts:
         - name: pkgs
           mountPath: /pkgs
-      {{- $distros := list }}
-      {{- if $.Values.distroAutoDetect }}
+      {{- $distros := $.Values.distros }}
+      {{- if $distros -}}
+      {{ else }}
+        {{- $distros = append $distros "flatcar" }}
         {{- range $index, $node := (lookup "v1" "Node" "" "").items }}
           {{- $osImage := lower $node.status.nodeInfo.osImage }}
           {{- with . -}}
@@ -38,10 +40,9 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
-      {{- else }}
-        {{- $distros = $.Values.distros -}}
       {{- end }}
       {{- range $index, $dist := $distros | uniq }}
+      {{- if regexMatch "^(rhel[78]|bionic|focal|jammy)$" $dist }}
       - name: {{ $dist }}
         image: {{ $.Values.registry }}/drbd9-{{ $dist }}:{{ $.Values.drbdVersion }}
         imagePullPolicy: {{ $.Values.imagePullPolicy }}
@@ -52,7 +53,7 @@ spec:
         - name: LB_DROP
           value: {{ $.Values.drop | quote }}
         volumeMounts:
-        {{- if regexMatch "rhel[78]" $dist }}
+        {{- if regexMatch "^rhel[78]$" $dist }}
         - name: centos-release
           mountPath: /etc/centos-release
           readOnly: true
@@ -71,6 +72,7 @@ spec:
           mountPath: /usr-local-bin
         - name: etc-modules-load
           mountPath: /etc/modules-load.d
+        {{- end }}
         {{- end }}
       containers:
       - name: monitor

--- a/helm/drbd-adapter/templates/drbd-adapter.yaml
+++ b/helm/drbd-adapter/templates/drbd-adapter.yaml
@@ -15,25 +15,28 @@ spec:
     spec:
       initContainers:
       - name: shipper
-        image: {{ .Values.registry}}/drbd9-shipper:{{ .Values.drbdVersion}}
-        imagePullPolicy: Always
+        image: {{ $.Values.registry }}/drbd9-shipper:{{ $.Values.drbdVersion }}
+        imagePullPolicy: {{ $.Values.imagePullPolicy }}
         volumeMounts:
         - name: pkgs
           mountPath: /pkgs
-
-      - name: rhel7
-        image: {{ .Values.registry}}/drbd9-rhel7:{{ .Values.drbdVersion}}
-        imagePullPolicy: Always
+      {{- range $.Values.distros }}
+      {{ $dist := . }}
+      - name: {{ $dist }}
+        image: {{ $.Values.registry }}/drbd9-{{ $dist }}:{{ $.Values.drbdVersion }}
+        imagePullPolicy: {{ $.Values.imagePullPolicy }}
         command: [ /pkgs/entrypoint.adapter.sh ]
         securityContext:
           privileged: true
         env:
         - name: LB_DROP
-          value: 'yes'
+          value: {{ $.Values.drop | quote }}
         volumeMounts:
+        {{- if regexMatch "rhel[78]" $dist }}
         - name: centos-release
           mountPath: /etc/centos-release
           readOnly: true
+        {{- end }}
         - name: pkgs
           mountPath: /pkgs
         - name: os-release
@@ -48,118 +51,16 @@ spec:
           mountPath: /usr-local-bin
         - name: etc-modules-load
           mountPath: /etc/modules-load.d
-
-      - name: rhel8
-        image: {{ .Values.registry}}/drbd9-rhel8:{{ .Values.drbdVersion}}
-        imagePullPolicy: Always
-        command: [ /pkgs/entrypoint.adapter.sh ]
-        securityContext:
-          privileged: true
-        env:
-        - name: LB_DROP
-          value: 'yes'
-        volumeMounts:
-        - name: centos-release
-          mountPath: /etc/centos-release
-          readOnly: true
-        - name: pkgs
-          mountPath: /pkgs
-        - name: os-release
-          mountPath: /etc/host-release
-          readOnly: true
-        - name: usr-src
-          mountPath: /usr/src
-          readOnly: true
-        - name: lib-modules
-          mountPath: /lib/modules
-        - name: usr-local-bin
-          mountPath: /usr-local-bin
-        - name: etc-modules-load
-          mountPath: /etc/modules-load.d
-
-      - name: bionic
-        image: {{ .Values.registry}}/drbd9-bionic:{{ .Values.drbdVersion}}
-        imagePullPolicy: Always
-        command: [ /pkgs/entrypoint.adapter.sh ]
-        securityContext:
-          privileged: true
-        env:
-        - name: LB_DROP
-          value: 'yes'
-        volumeMounts:
-        - name: pkgs
-          mountPath: /pkgs
-        - name: os-release
-          mountPath: /etc/host-release
-          readOnly: true
-        - name: usr-src
-          mountPath: /usr/src
-          readOnly: true
-        - name: lib-modules
-          mountPath: /lib/modules
-        - name: usr-local-bin
-          mountPath: /usr-local-bin
-        - name: etc-modules-load
-          mountPath: /etc/modules-load.d
-
-      - name: focal
-        image: {{ .Values.registry}}/drbd9-focal:{{ .Values.drbdVersion}}
-        imagePullPolicy: Always
-        command: [ /pkgs/entrypoint.adapter.sh ]
-        securityContext:
-          privileged: true
-        env:
-        - name: LB_DROP
-          value: 'yes'
-        volumeMounts:
-        - name: pkgs
-          mountPath: /pkgs
-        - name: os-release
-          mountPath: /etc/host-release
-          readOnly: true
-        - name: usr-src
-          mountPath: /usr/src
-          readOnly: true
-        - name: lib-modules
-          mountPath: /lib/modules
-        - name: usr-local-bin
-          mountPath: /usr-local-bin
-        - name: etc-modules-load
-          mountPath: /etc/modules-load.d
-
-      - name: jammy
-        image: {{ .Values.registry}}/drbd9-jammy:{{ .Values.drbdVersion}}
-        imagePullPolicy: Always
-        command: [ /pkgs/entrypoint.adapter.sh ]
-        securityContext:
-          privileged: true
-        env:
-        - name: LB_DROP
-          value: 'yes'
-        volumeMounts:
-        - name: pkgs
-          mountPath: /pkgs
-        - name: os-release
-          mountPath: /etc/host-release
-          readOnly: true
-        - name: usr-src
-          mountPath: /usr/src
-          readOnly: true
-        - name: lib-modules
-          mountPath: /lib/modules
-        - name: usr-local-bin
-          mountPath: /usr-local-bin
-        - name: etc-modules-load
-          mountPath: /etc/modules-load.d
-
+        {{- end }}
       containers:
       - name: monitor
-        image: quay.io/piraeusdatastore/drbd-reactor
-        imagePullPolicy: IfNotPresent
+        # Source registry: quay.io/piraeusdatastore/drbd-reactor
+        image: {{ .Values.registry}}/drbd-reactor:{{ .Values.drbdReactorVersion}}
+        imagePullPolicy: {{ .Values.imagePullPolicy}}
         command:
-        - tail
-        - -f
-        - /dev/null
+        - /usr/sbin/drbd-reactor
+        - -c
+        - /pkgs/drbd-reactor.toml
         volumeMounts:
         - name: pkgs
           mountPath: /pkgs
@@ -187,7 +88,6 @@ spec:
       - name: etc-modules-load
         hostPath:
           path: /etc/modules-load.d
-
       affinity:
         nodeAffinity:
-		 {{- toYaml .Values.affinity.nodeAffinity | nindent 10 }}
+		    {{- toYaml $.Values.affinity.nodeAffinity | nindent 10 }}

--- a/helm/drbd-adapter/templates/drbd-adapter.yaml
+++ b/helm/drbd-adapter/templates/drbd-adapter.yaml
@@ -20,8 +20,28 @@ spec:
         volumeMounts:
         - name: pkgs
           mountPath: /pkgs
-      {{- range $.Values.distros }}
-      {{ $dist := . }}
+      {{- $distros := list }}
+      {{- if $.Values.distroAutoDetect }}
+        {{- range $index, $node := (lookup "v1" "Node" "" "").items }}
+          {{- $osImage := lower $node.status.nodeInfo.osImage }}
+          {{- with . -}}
+            {{- if regexMatch "centos .*7" $osImage }}
+              {{- $distros = append $distros "rhel7" }}
+            {{- else if regexMatch "centos .*8" $osImage }}
+              {{- $distros = append $distros "rhel8" }}
+            {{- else if regexMatch "ubuntu .*18" $osImage }}
+              {{- $distros = append $distros "bionic" }}
+            {{- else if regexMatch "ubuntu .*20" $osImage }}
+              {{- $distros = append $distros "focal" }}
+            {{- else if regexMatch "ubuntu .*22" $osImage }}
+              {{- $distros = append $distros "jammy" }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- else }}
+        {{- $distros = $.Values.distros -}}
+      {{- end }}
+      {{- range $index, $dist := $distros | uniq }}
       - name: {{ $dist }}
         image: {{ $.Values.registry }}/drbd9-{{ $dist }}:{{ $.Values.drbdVersion }}
         imagePullPolicy: {{ $.Values.imagePullPolicy }}

--- a/helm/drbd-adapter/values.yaml
+++ b/helm/drbd-adapter/values.yaml
@@ -4,12 +4,14 @@ imagePullPolicy: IfNotPresent # For testing, set 'Always'
 drbdVersion: v9.1.8
 drbdReactorVersion: v0.8.0
 # Here are all supported distros, remove the ones that are not in your cluster
-distros:
-  - rhel7
-  - rhel8
-  - bionic
-  - focal
-  - jammy
+
+distroAutoDetect: true
+distros: # will be ignored if "distroAutoDetect" is set to true
+  # - rhel7
+  # - rhel8
+  # - bionic
+  # - focal
+  # - jammy
 
 # by default drop binary files to the host
 drop: "yes"

--- a/helm/drbd-adapter/values.yaml
+++ b/helm/drbd-adapter/values.yaml
@@ -5,13 +5,12 @@ drbdVersion: v9.1.8
 drbdReactorVersion: v0.8.0
 # Here are all supported distros, remove the ones that are not in your cluster
 
-distroAutoDetect: true
-distros: # will be ignored if "distroAutoDetect" is set to true
-  # - rhel7
-  # - rhel8
-  # - bionic
-  # - focal
-  # - jammy
+distros: []  # Must be set as "[]" (empty array) to enable AutoDetect"
+# - rhel7
+# - rhel8
+# - bionic
+# - focal
+# - jammy
 
 # by default drop binary files to the host
 drop: "yes"

--- a/helm/drbd-adapter/values.yaml
+++ b/helm/drbd-adapter/values.yaml
@@ -1,15 +1,26 @@
-# Default values for drbd-adapter.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 registry: ghcr.io/hwameistor
+imagePullPolicy: IfNotPresent # For testing, set 'Always'
 
 drbdVersion: v9.1.8
+drbdReactorVersion: v0.8.0
+# Here are all supported distros, remove the ones that are not in your cluster
+distros:
+  - rhel7
+  - rhel8
+  - bionic
+  - focal
+  - jammy
 
+# by default drop binary files to the host
+drop: "yes"
+
+# Aovid master nodes
 affinity: 
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
       - matchExpressions:
         - key: node-role.kubernetes.io/master
+          operator: DoesNotExist
+        - key: node-role.kubernetes.io/control-plane
           operator: DoesNotExist


### PR DESCRIPTION
This PR brings 

1. Auto-Detect distro when `distros: []`  in value.yaml, using helm `lookup` function 
2. Auto-Detect can be overridden when array `distros` has values, for example: `distros: [ "rhel7", "focal"]`
3. Ignore distros that is not supported

Fixes
1. Fix issue: `modinfo` displaying drbd 8.x on Ubuntu
2. Fix issue: only install if the running drbd module of a lower version
3. Fix issue: `imagePullPolicy: IfNotPresent` as default 
4. Fix issue: specify `drbd-reactor` version
5. Fix issue: affinity to avoid k8s master by `node-role.kubernetes.io/control-plane`