### PR TITLE
[fix] link /etc => /usr/local/etc and /var /usr/local/var

### DIFF
--- a/docker-shipper/entrypoint.adapter.sh
+++ b/docker-shipper/entrypoint.adapter.sh
@@ -75,8 +75,8 @@ if [[ $LB_DROP == yes ]]; then
    cp -vf /pkgs/drbd-utils/* /usr-local/bin/
    cat /pkgs/drbd.conf > /etc/drbd.conf
    cp -vf /pkgs/global_common.conf /etc/drbd.d/
-   mkdir -vp /usr-local/etc /usr-local/var/lib
-   ln -svf /etc/drbd.conf /usr-local/etc/drbd.conf
-   ln -svf /etc/drbd.d /usr-local/etc/drbd.d
-   ln -svf /var/lib/drbd /usr-local/var/lib/
+   for i in etc var; do 
+      mv -vf /usr-local/$i /usr-local/$i.bak
+      ln -svf /$i /usr-local/$i
+   done 
 fi


### PR DESCRIPTION
Signed-off-by: alexzhc <alex.zheng@daocloud.io>

It is observed that for statically-compiled `drbdadm`, the working directory is /usr/local, therefore we device a temporary fix for the problem of `drbadm` no finding `/usr/local/etc` and `/usr/local/var`

```
   for i in etc var; do 
      mv -vf /usr-local/$i /usr-local/$i.bak
      ln -svf /$i /usr-local/$i
   done 
``` 