### PR TITLE
specify lib dir before compile drbd-utils

### DIFF
--- a/docker-shipper/Dockerfile.shipper
+++ b/docker-shipper/Dockerfile.shipper
@@ -48,6 +48,8 @@ RUN set -x && \
           --without-manual \
           --without-xen \
           --without-heartbeat \
+          --sysconfdir=/etc \
+          --localstatedir=/var \
           CFLAGS="-static" \
           LDFLAGS="-static" && \
           make tools && \

--- a/docker-shipper/entrypoint.adapter.sh
+++ b/docker-shipper/entrypoint.adapter.sh
@@ -78,10 +78,6 @@ if [[ $LB_DROP == yes ]]; then
    cat /pkgs/drbd.conf > /etc/drbd.conf
    cp -vf /pkgs/global_common.conf /etc/drbd.d/
    
-   for i in etc var; do 
-      mv -vf /usr-local/$i /usr-local/$i.bak
-      ln -svf /$i /usr-local/$i
-   done 
 fi
 
 # Check if DRBD is loaded correctly


### PR DESCRIPTION
## What's the problem
To fix https://github.com/hwameistor/hwameistor/issues/277.

This error can be avoided during compilation by [declaring the path of the configuration file](https://github.com/LINBIT/drbd-utils/blob/12dc82d8d24c2f9062a0b97cd789cf45e13a0e56/configure.ac#L466)